### PR TITLE
Add help text for the 'spr diff --stack' option

### DIFF
--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -28,6 +28,10 @@ pub struct DiffOptions {
     #[clap(long, short = 'm')]
     message: Option<String>,
 
+    /// Stack this Pull Request onto another one. Valid values are a Pull
+    /// Request number, or 'parent' to look up the Pull Request number from the
+    /// parent commit. To turn an existing Pull Request into one that is not
+    /// stacked, use '--stack none'.
     #[clap(long, rename_all = "lower")]
     stack: Option<StackOption>,
 }


### PR DESCRIPTION
Summary: Apparently I forgot this earlier.

Test Plan: run `spr diff --help`
