### PR TITLE
After landing a Pull Request, delete the old branch on GitHub

### DIFF
--- a/src/commands/land.rs
+++ b/src/commands/land.rs
@@ -174,6 +174,8 @@ pub async fn land(
             .arg("--")
             .arg(&config.remote_name)
             .arg(&pull_request.head)
+            .stdout(async_process::Stdio::null())
+            .stderr(async_process::Stdio::null())
             .spawn()?;
 
     // Rebase us on top of the now-landed commit


### PR DESCRIPTION
Summary:
GitHub may do this automatically, if it's configured that way, but it doesn't hurt to just try do it. The exit code from 'git push' is ignored anyway.

Test Plan:
Land a PR with `spr land` in a repo that is not configured to automatically delete PR branches.
