### PR TITLE
Fix regex for parsing section labels in commit messages

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -51,7 +51,7 @@ pub fn parse_message(
     msg: &str,
     top_section: MessageSection,
 ) -> MessageSectionsMap {
-    let regex = lazy_regex::regex!(r#"\s*([\w\s]+?)\s*:\s*(.*)$"#);
+    let regex = lazy_regex::regex!(r#"^\s*([\w\s]+?)\s*:\s*(.*)$"#);
 
     let mut section = top_section;
     let mut lines_in_section = Vec::<&str>::new();
@@ -274,14 +274,18 @@ Test plan: testzzz
 Summary:
 here is
 the
-summary
+summary (it's not a "Test plan:"!)
 
 Reviewer:    a, b, c"#,
                 MessageSection::Title
             ),
             [
                 (MessageSection::Title, "Hello".to_string()),
-                (MessageSection::Summary, "here is\nthe\nsummary".to_string()),
+                (
+                    MessageSection::Summary,
+                    "here is\nthe\nsummary (it's not a \"Test plan:\"!)"
+                        .to_string()
+                ),
                 (MessageSection::TestPlan, "testzzz".to_string()),
                 (MessageSection::Reviewers, "a, b, c".to_string()),
             ]


### PR DESCRIPTION
There was a bad error in the regex for identifying labels (e.g. "Test Plan:") in the commit message. It looked for alphanumeric/space characters followed by a colon, but didn't look only at the beginnings of lines.
So a line having "Summary:" somewhere in the middle (like this one) was treated like the "Summary:" label.

Test amended to catch this.

Test Plan: `spr format` on this commit, `cargo test`
