### PR TITLE
Remove the "Summary:" label from commit messages

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -121,7 +121,7 @@ pub fn build_message(
     sections: &[MessageSection],
 ) -> String {
     let mut result = String::new();
-    let mut first_section = true;
+    let mut display_label = false;
 
     for section in sections {
         let value = section_texts.get(section);
@@ -129,7 +129,16 @@ pub fn build_message(
             if !result.is_empty() {
                 result.push('\n');
             }
-            if !first_section || section != &MessageSection::Title {
+
+            if section != &MessageSection::Title
+                && section != &MessageSection::Summary
+            {
+                // Once we encounter a section that's neither Title nor Summary,
+                // we start displaying the labels.
+                display_label = true;
+            }
+
+            if display_label {
                 let label = message_section_label(section);
                 result.push_str(label);
                 result.push_str(
@@ -140,10 +149,10 @@ pub fn build_message(
                     },
                 );
             }
+
             result.push_str(text);
             result.push('\n');
         }
-        first_section = false;
     }
 
     result


### PR DESCRIPTION
It's kind of pointless to have. The commit message begins with a title (first line), and what follows summarises what's done in the commit. We don't need a "Summary:" label for that.
This diff makes it so that when we construct messages (either commit messages or the bodies of Pull Requests), we omit labels until we get to the first section that's neither Summary or Title.
So internally we keep the separate Summary section, we just don't label it.
Which makes this backwards-compatible: messages which have the "Summary:" label get parsed correctly.

Test Plan:
build, and use this version to do the "spr diff" and "spr land" of this commit. Check that the Pull Request body is constructed correctly, and that it gets converted to the final commit message correctly.
Also, try "spr format" with commit messages with and without "Summary:" label.
