### PR TITLE
Fix "cargo clippy" lint issues

### DIFF
--- a/src/commands/land.rs
+++ b/src/commands/land.rs
@@ -28,7 +28,7 @@ pub async fn land(
         }
     };
 
-    write_commit_title(&prepared_commit)?;
+    write_commit_title(prepared_commit)?;
 
     let pull_request_number =
         if let Some(number) = prepared_commit.pull_request_number {
@@ -164,7 +164,7 @@ pub async fn land(
     } else {
         output("❌", "GitHub Pull Request merge failed")?;
 
-        return Err(merge.message.map(Error::new).unwrap_or(Error::empty()));
+        return Err(merge.message.map(Error::new).unwrap_or_else(Error::empty));
     }
 
     // Rebase us on top of the now-landed commit
@@ -191,15 +191,14 @@ pub async fn land(
                 return Err(Error::new("git fetch failed"));
             }
         }
-        drop(prepared_commit);
         git.rebase_commits(
             &mut prepared_commits[..],
             git2::Oid::from_str(&sha)?,
         )
         .await
-        .context(format!(
-            "The automatic rebase failed - please rebase manually!"
-        ))?;
+        .context(
+            "The automatic rebase failed - please rebase manually!".to_string(),
+        )?;
     }
 
     Ok(())


### PR DESCRIPTION
Summary:
Running clippy generated the following:
```
$ cargo clippy
    Checking spr v1.0.0 (/Users/jozef/spr)
warning: this expression borrows a reference (`&git::PreparedCommit`) that is immediately dereferenced by the compiler
  --> src/commands/land.rs:31:24
   |
31 |     write_commit_title(&prepared_commit)?;
   |                        ^^^^^^^^^^^^^^^^ help: change this to: `prepared_commit`
   |
   = note: `#[warn(clippy::needless_borrow)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: use of `unwrap_or` followed by a function call
   --> src/commands/land.rs:167:50
    |
167 |         return Err(merge.message.map(Error::new).unwrap_or(Error::empty()));
    |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(Error::empty)`
    |
    = note: `#[warn(clippy::or_fun_call)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#or_fun_call

error: calls to `std::mem::drop` with a reference instead of an owned value. Dropping a reference does nothing
   --> src/commands/land.rs:194:9
    |
194 |         drop(prepared_commit);
    |         ^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[deny(clippy::drop_ref)]` on by default
note: argument has type `&mut git::PreparedCommit`
   --> src/commands/land.rs:194:14
    |
194 |         drop(prepared_commit);
    |              ^^^^^^^^^^^^^^^
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#drop_ref

warning: useless use of `format!`
   --> src/commands/land.rs:200:18
    |
200 |           .context(format!(
    |  __________________^
201 | |             "The automatic rebase failed - please rebase manually!"
202 | |         ))?;
    | |_________^ help: consider using `.to_string()`: `"The automatic rebase failed - please rebase manually!".to_string()`
    |
    = note: `#[warn(clippy::useless_format)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_format
```

Test Plan: `cargo clippy` is happy now
