### PR TITLE
Print PR link after "spr diff"

### DIFF
--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -412,6 +412,7 @@ pub async fn diff(
                 "✨",
                 &format!(
                     "Created new Pull Request #{}: {}",
+                    pull_request_number,
                     config.pull_request_url(pull_request_number)
                 ),
             )?;


### PR DESCRIPTION


Test Plan:
will run "spr diff" on this commit and paste the new output
here:

(only the LAST line is different)
```
$ cargo run --release diff
   Compiling spr v1.0.0 (/Users/jozef/spr)
    Finished release [optimized] target(s) in 14.64s
     Running `target/release/spr diff`
3569bfe Print PR link after "spr diff"
  🛬  This Pull Request is for landing on the 'master' branch
Enter passphrase for key '/Users/jozef/.ssh/id_ecdsa':
  ✨  Created new Pull Request https://github.com/getcord/spr/pull/6
```
