### PR TITLE
[Bug fix] User may have made multiple reviews

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -240,8 +240,8 @@ impl GitHub {
                             for reviewer in reviewers_list {
                                 match reviewer.state.as_str() {
                                     "APPROVED" => {
-                                        // approvals from users that we still
-                                        // want review from don't count
+                                        // approvals from users from which we still
+                                        // want a review don't count
                                         if reviewers.get(&reviewer.user.login)
                                             == Some(&ReviewStatus::Requested)
                                         {
@@ -255,8 +255,8 @@ impl GitHub {
                                         );
                                     }
                                     "CHANGES_REQUESTED" => {
-                                        // rejections from users that we still
-                                        // want review do count
+                                        // rejections from users from which we still
+                                        // want a review still count as rejections
                                         review_status =
                                             Some(ReviewStatus::Rejected);
                                         if reviewers.get(&reviewer.user.login)


### PR DESCRIPTION
Currently if a user requests changes and later accepts, the
accept would be skipped over (the "continue" branch) because we already
saw "changes_requested" from this user. This bug happened during
Friday's demo with https://github.com/getcord/test-repository/pull/32
where I requested changes first and then accepted. Sven was not able to
land the PR until Alberto accepted (his accept was not skipped by the
loop).

We still however want to skip accepts/change requests if the PR author
has since requested review.

Test Plan:
I am a bit lazy to test it fully, but I checked what
Githubs's API give us when we ask for "reviews":

```
$ curl -u jozef-mokry https://api.github.com/repos/getcord/test-repository/pulls/32/reviews 2>/dev/null | jq ".[] | {user: .user.login, state: .state, time: .submitted_at}"
{
  "user": "jozef-mokry",
  "state": "COMMENTED",
  "time": "2022-02-11T13:16:52Z"
}
{
  "user": "flooey",
  "state": "APPROVED",
  "time": "2022-02-11T13:16:52Z"
}
{
  "user": "sven-of-cord",
  "state": "COMMENTED",
  "time": "2022-02-11T13:17:14Z"
}
{
  "user": "AlbertQM",
  "state": "COMMENTED",
  "time": "2022-02-11T13:17:19Z"
}
{
  "user": "jozef-mokry",
  "state": "CHANGES_REQUESTED",
  "time": "2022-02-11T13:25:12Z"
}
{
  "user": "jozef-mokry",
  "state": "APPROVED", <--- This accept would be currently ignored!
  "time": "2022-02-11T13:30:28Z"
}
{
  "user": "AlbertQM",
  "state": "APPROVED",
  "time": "2022-02-11T13:34:37Z"
}
```
