### PR TITLE
Remove Mutex around repo

### DIFF
--- a/src/commands/amend.rs
+++ b/src/commands/amend.rs
@@ -17,7 +17,7 @@ pub async fn amend(
     gh: &mut crate::github::GitHub,
     config: &crate::config::Config,
 ) -> Result<()> {
-    let mut pc = git.get_prepared_commits(config).await?;
+    let mut pc = git.get_prepared_commits(config)?;
 
     let len = pc.len();
     if len == 0 {
@@ -55,7 +55,7 @@ pub async fn amend(
         }
         failure = validate_commit_message(&commit.message).is_err() || failure;
     }
-    git.rewrite_commit_messages(slice, None).await?;
+    git.rewrite_commit_messages(slice, None)?;
 
     if failure {
         Err(Error::empty())

--- a/src/commands/format.rs
+++ b/src/commands/format.rs
@@ -16,7 +16,7 @@ pub async fn format(
     git: &crate::git::Git,
     config: &crate::config::Config,
 ) -> Result<()> {
-    let mut pc = git.get_prepared_commits(config).await?;
+    let mut pc = git.get_prepared_commits(config)?;
 
     let len = pc.len();
     if len == 0 {
@@ -37,7 +37,7 @@ pub async fn format(
         write_commit_title(commit)?;
         failure = validate_commit_message(&commit.message).is_err() || failure;
     }
-    git.rewrite_commit_messages(slice, None).await?;
+    git.rewrite_commit_messages(slice, None)?;
 
     if failure {
         Err(Error::empty())

--- a/src/commands/land.rs
+++ b/src/commands/land.rs
@@ -18,7 +18,7 @@ pub async fn land(
     gh: &mut crate::github::GitHub,
     config: &crate::config::Config,
 ) -> Result<()> {
-    let mut prepared_commits = git.get_prepared_commits(config).await?;
+    let mut prepared_commits = git.get_prepared_commits(config)?;
 
     let prepared_commit = match prepared_commits.last_mut() {
         Some(c) => c,
@@ -120,10 +120,9 @@ pub async fn land(
         return Err(Error::new("git fetch failed"));
     }
 
-    let current_master =
-        git.resolve_reference(&config.remote_master_ref).await?;
+    let current_master = git.resolve_reference(&config.remote_master_ref)?;
 
-    let index = git.cherrypick(prepared_commit.oid, current_master).await?;
+    let index = git.cherrypick(prepared_commit.oid, current_master)?;
 
     if index.has_conflicts() {
         return Err(Error::new(formatdoc!(
@@ -136,10 +135,9 @@ pub async fn land(
 
     // This is the tree we are getting from cherrypicking the local commit
     // on the selected base (master or stacked-on Pull Request).
-    let our_tree_oid = git.write_index(index).await?;
+    let our_tree_oid = git.write_index(index)?;
 
-    let github_tree_oid =
-        git.get_tree_oid_for_commit(github_merge_commit).await?;
+    let github_tree_oid = git.get_tree_oid_for_commit(github_merge_commit)?;
 
     if our_tree_oid != github_tree_oid {
         return Err(Error::new(formatdoc!(
@@ -206,7 +204,6 @@ pub async fn land(
             &mut prepared_commits[..],
             git2::Oid::from_str(&sha)?,
         )
-        .await
         .context(
             "The automatic rebase failed - please rebase manually!".to_string(),
         )?;


### PR DESCRIPTION
It was not needed and this way we can turn a lot of the "async"
functions into normal functions

Test Plan:
cargo build
cargo run diff
