### PR TITLE
Dont diff/land if there are uncommited changes

### DIFF
--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -72,6 +72,7 @@ pub async fn diff(
     gh: &mut crate::github::GitHub,
     config: &crate::config::Config,
 ) -> Result<()> {
+    git.check_no_uncommitted_changes()?;
     let mut prepared_commits = git.get_prepared_commits(config)?;
 
     let base_oid = prepared_commits[0].parent_oid;

--- a/src/commands/land.rs
+++ b/src/commands/land.rs
@@ -18,6 +18,7 @@ pub async fn land(
     gh: &mut crate::github::GitHub,
     config: &crate::config::Config,
 ) -> Result<()> {
+    git.check_no_uncommitted_changes()?;
     let mut prepared_commits = git.get_prepared_commits(config)?;
 
     let prepared_commit = match prepared_commits.last_mut() {

--- a/src/git.rs
+++ b/src/git.rs
@@ -318,4 +318,16 @@ impl Git {
 
         Ok(oid)
     }
+
+    pub fn check_no_uncommitted_changes(&self) -> Result<()> {
+        let mut opts = git2::StatusOptions::new();
+        opts.include_ignored(false).include_untracked(false);
+        if self.repo.statuses(Some(&mut opts))?.len() == 0 {
+            return Ok(());
+        } else {
+            return Err(Error::new(
+                "There are uncommitted changes. Stash or amend them first",
+            ));
+        }
+    }
 }


### PR DESCRIPTION
Summary:
`arc` had this behaviour and I think even during the demo Sven got burned by this check missing.

Test Plan:
```
(jozef/reviews) jozef:~/spr $ git status
On branch jozef/reviews
Your branch is ahead of 'origin/master' by 2 commits.
  (use "git push" to publish your local commits)

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   src/git.rs

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        dummy_untracked

no changes added to commit (use "git add" and/or "git commit -a")


(jozef/reviews) jozef:~/spr $ cargo run diff
  🛑  There are uncommitted changes. Stash or amend them first

(jozef/reviews) jozef:~/spr $ git commit --amend -a

(jozef/reviews) jozef:~/spr $ cargo run diff
3e61f1a Dont diff/land if there are uncommited changes
  🛬  This Pull Request is for landing on the 'master' branch
  ✨  Created new Pull Request #11: https://github.com/getcord/spr/pull/11
```
