### PR TITLE
When rebasing after land, check out the newly rebased branch correctly

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -172,7 +172,7 @@ impl Git {
         // or commit), the rebase should work nicely.
         self.repo
             .checkout_tree(new_commit.as_object(), None)
-            .map_err(|e| Error::from(e))
+            .map_err(Error::from)
             .reword(
                 "Could not check out rebased branch - please rebase manually"
                     .into(),


### PR DESCRIPTION
We found that when on a branch that is based on an older version master, landing a diff has a weird side effect: the current branch is now based on current master, but the worktree did not receive the changes from the intermediate master commits (those between the pre-land base of the local branch and current master). It looks like changes reverting those commits are staged. If you were to run git add and git commit now, the created commit would not only have the intended changes in it, but also changes reverting recent commits on master.
This commit fixes it. Instead of just setting the branch to point at the newly rebased commits, we also have to check them out.

Test Plan:
In a test repository, start a new branch on an outdated master commit (e.g. `git checkout -b new-branch origin/master~5`), produce a new commit, `spr diff` and `spr land`. Without the changes in this commit, the changes from `origin/master~5` to `origin/master` (pre-land) would be reverted in the local worktree. With this commit, this does not happen.
Also try to have mulitple commits on the local branch and try running `spr land` as part of a `git rebase --interactive`.
