### PR TITLE
Refuse to work on commit messages without title

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -204,6 +204,16 @@ pub fn validate_commit_message(message: &MessageSectionsMap) -> Result<()> {
         output("💔", "Commit message does not have a Test Plan!")?;
         return Err(Error::empty());
     }
+
+    let title_missing_or_empty = match message.get(&MessageSection::Title) {
+        None => true,
+        Some(title) => title.is_empty(),
+    };
+    if title_missing_or_empty {
+        output("💔", "Commit message does not have a title!")?;
+        return Err(Error::empty());
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
Submitting a Pull Request fails when the commit message has no title (e.g. starts with "Test Plan:" right away). It fails because the branch name constructed from the title is invalid (at least if the branch name prefix ends in '/').
Instead, with this change, you'll get an error explicitly pointing out the missing title.

Test Plan:
try to submit this commit with no title in the commit message. (Start the message with 'Test plan:' to do that). spr should refuse to create the Pull Request, and complain about the lack of a title in the commit message.
Also: run `spr format` with a commit message without title in the local branch. It should complain.
