### PR TITLE
README.md: add installation using Cargo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ spr is pronounced /ˈsuːpəɹ/, like the English word 'super'.
 
 ## Installation
 
+### Binary Installation
+
+#### Using Cargo
+
+If you have Cargo installed (the Rust build tool), you can install spr by running `cargo install spr`.
+
 ### Install from Source
 
 spr is written in Rust. You need a Rust toolchain to build from source. See [rustup.rs](https://rustup.rs) for information on how to install Rust if you have not got a Rust toolchain on your system already.


### PR DESCRIPTION
I have just published spr on crates.io. That means there is an easy way available for anyone who has a Rust toolchain, without cloning the Git repo.

Test Plan: I tried `cargo install spr` - it worked just fine.
