### PR TITLE
Downgrade git2 to fix build with homebrew-installed Rust 1.59

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.2.3] - 2022-05-24
+
+### Fixes
+
+- fix building with homebrew-installed Rust (currently 1.59)
+
 ## [1.2.2] - 2022-05-23
 
 ### Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -599,9 +599,9 @@ checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
 name = "git2"
-version = "0.14.4"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0155506aab710a86160ddb504a480d2964d7ab5b9e62419be69e0032bc5931c"
+checksum = "3826a6e0e2215d7a41c2bfc7c9244123969273f3476b939a226aac0ab56e9e3c"
 dependencies = [
  "bitflags",
  "libc",
@@ -929,9 +929,9 @@ checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.13.4+1.4.2"
+version = "0.13.2+1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0fa6563431ede25f5cc7f6d803c6afbc1c5d3ad3d4925d12c882bf2b526f5d1"
+checksum = "3a42de9a51a5c12e00fc0e4ca6bc2ea43582fc6418488e8f615e905d886f258b"
 dependencies = [
  "cc",
  "libc",
@@ -1576,7 +1576,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spr"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "async-compat",
  "async-executor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spr"
-version = "1.2.2"
+version = "1.2.3"
 authors = ["Sven Over <sven@cord.com>", "Jozef Mokry <jozef@cord.com>"]
 description = "Submit pull requests for individual, amendable, rebaseable commits to GitHub"
 repository = "https://github.com/getcord/spr"
@@ -19,7 +19,7 @@ console = "^0.15.0"
 dialoguer = "^0.10.1"
 futures = "^0.3.21"
 futures-lite = "^1.12.0"
-git2 = "^0.14.4"
+git2 = "^0.14.2"
 indoc = "^1.0.3"
 lazy-regex = "^2.2.2"
 octocrab = "^0.16.0"


### PR DESCRIPTION
I am setting up a homebrew formula for spr. It depends on Rust, obviously. The homebrew-installed Rust toolchain (currently 1.59) has a problem with the git2 dependency, which I could fix by downgrading it slightly.
This commit also bumps the version number for release.

Test Plan:
`cargo check`
I am also using a Docker container (`docker run --rm=true -it homebrew/brew`) to have a clean homebrew set up. With this change, I can use the homebrew-installed Rust to build spr.
