### PR TITLE
Add homebrew section to binary installation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ spr is pronounced /ˈsuːpəɹ/, like the English word 'super'.
 
 ### Binary Installation
 
+#### Using Homebrew
+
+```shell
+brew install getcord/tap/spr
+```
+
 #### Using Cargo
 
 If you have Cargo installed (the Rust build tool), you can install spr by running `cargo install spr`.


### PR DESCRIPTION


Test Plan:
I tested the given command line inside a homebrew Docker container (`docker run --rm=true -it homebrew/brew`)
