### PR TITLE
Fix PullRequestQuery GraphQL query for repositories not owned by orgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.2.4] - 2022-05-26
+
+### Fixes
+
+- fix working with repositories not owned by an organization but by a user
+
 ## [1.2.3] - 2022-05-24
 
 ### Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1576,7 +1576,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spr"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "async-compat",
  "async-executor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spr"
-version = "1.2.3"
+version = "1.2.4"
 authors = ["Sven Over <sven@cord.com>", "Jozef Mokry <jozef@cord.com>"]
 description = "Submit pull requests for individual, amendable, rebaseable commits to GitHub"
 repository = "https://github.com/getcord/spr"

--- a/src/github.rs
+++ b/src/github.rs
@@ -190,8 +190,6 @@ impl GitHub {
         let pr = response_body
             .data
             .ok_or_else(|| Error::new("failed to fetch PR"))?
-            .organization
-            .ok_or_else(|| Error::new("failed to find organization"))?
             .repository
             .ok_or_else(|| Error::new("failed to find repository"))?
             .pull_request
@@ -253,7 +251,7 @@ impl GitHub {
             .flatten()
             .flat_map(|x| &x.requested_reviewer)
             .flat_map(|reviewer| {
-              type UserType = pull_request_query::PullRequestQueryOrganizationRepositoryPullRequestReviewRequestsNodesRequestedReviewer;
+              type UserType = pull_request_query::PullRequestQueryRepositoryPullRequestReviewRequestsNodesRequestedReviewer;
               match reviewer {
                 UserType::User(user) => Some(user.login.clone()),
                 UserType::Team(team) => Some(format!("#{}", team.slug)),

--- a/src/gql/pullrequest_query.graphql
+++ b/src/gql/pullrequest_query.graphql
@@ -1,38 +1,36 @@
 query PullRequestQuery($name: String!, $owner: String!, $number: Int!) {
-  organization(login: $owner) {
-    repository(name: $name) {
-      pullRequest(number: $number) {
-        number
-        state
-        reviewDecision
-        title
-        body
-        baseRefName
-        baseRefOid
-        headRefOid
-        headRefName
-        mergeCommit {
-          oid
-        }
-        latestOpinionatedReviews(last: 100) {
-          nodes {
-            author {
-              __typename
-              login
-            }
-            state
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+       number
+      state
+      reviewDecision
+      title
+      body
+      baseRefName
+      baseRefOid
+      headRefOid
+      headRefName
+      mergeCommit {
+        oid
+      }
+      latestOpinionatedReviews(last: 100) {
+        nodes {
+          author {
+            __typename
+            login
           }
+          state
         }
-        reviewRequests(last: 100) {
-          nodes {
-            requestedReviewer {
-              __typename
-              ... on Team {
-                slug
-              }
-              ... on User {
-                login
-              }
+      }
+      reviewRequests(last: 100) {
+        nodes {
+          requestedReviewer {
+            __typename
+            ... on Team {
+              slug
+            }
+            ... on User {
+              login
             }
           }
         }

--- a/src/gql/pullrequest_query.graphql
+++ b/src/gql/pullrequest_query.graphql
@@ -1,7 +1,7 @@
 query PullRequestQuery($name: String!, $owner: String!, $number: Int!) {
   repository(owner: $owner, name: $name) {
     pullRequest(number: $number) {
-       number
+      number
       state
       reviewDecision
       title


### PR DESCRIPTION
GitHub repositories can be owned by users or orgs. The way the PullRequestQuery was phrased it threw an error if the repository used was owned by a user. This commit fixes that.

Test Plan:
update an existing PR in repositories both owned by a user and an org.
