### PR TITLE
Make land command reject local changes on land

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Improvements
+
+- make land command reject local changes on land
+
 ## [1.2.4] - 2022-05-26
 
 ### Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1580,6 +1580,7 @@ version = "1.2.4"
 dependencies = [
  "async-compat",
  "async-executor",
+ "async-io",
  "async-lock",
  "async-process",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ exclude = [".github", ".gitignore"]
 [dependencies]
 async-compat = "^0.2.1"
 async-executor = "^1.4.1"
+async-io = "^1.6.0"
 async-lock = "^2.4.0"
 async-process = "^1.3.0"
 clap = { version = "^3.0.14", features = ["derive", "wrap_help"] }

--- a/src/commands/land.rs
+++ b/src/commands/land.rs
@@ -7,7 +7,7 @@
 
 use async_compat::CompatExt;
 use indoc::formatdoc;
-use std::io::Write;
+use std::{io::Write, time::Duration};
 
 use crate::{
     error::{Error, Result, ResultExt},
@@ -27,17 +27,37 @@ pub async fn land(
     config: &crate::config::Config,
 ) -> Result<()> {
     git.check_no_uncommitted_changes()?;
-    let mut prepared_commits = git.get_prepared_commits(config)?;
 
-    let prepared_commit = match prepared_commits.last_mut() {
-        Some(c) => c,
-        None => {
-            output("👋", "Branch is empty - nothing to do. Good bye!")?;
-            return Ok(());
-        }
-    };
+    let head_oid = git.head()?;
+    let head_commit = git.repo().find_commit(head_oid)?;
+    let head_parent_count = head_commit.parent_count();
 
-    write_commit_title(prepared_commit)?;
+    if head_parent_count > 1 {
+        return Err(Error::new("Cannot land merge commits."));
+    }
+    if head_parent_count != 1 {
+        return Err(Error::new("Cannot land commit with no parents."));
+    }
+
+    let master_oid = git.resolve_reference(&config.remote_master_ref)?;
+    let merge_base = git.repo().merge_base(head_oid, master_oid)?;
+
+    if merge_base == head_oid {
+        output("👋", "Branch is empty - nothing to do. Good bye!")?;
+        return Ok(());
+    }
+
+    if head_commit.parent_id(0)? != merge_base {
+        return Err(Error::new(formatdoc!(
+            "Cannot land a commit whose parent is not on {master}. To land \
+             this commit, rebase it so that it is a direct child of {master}.",
+            master = &config.master_branch,
+        )));
+    }
+
+    let prepared_commit = git.prepare_commit(config, head_oid)?;
+
+    write_commit_title(&prepared_commit)?;
 
     let pull_request_number =
         if let Some(number) = prepared_commit.pull_request_number {
@@ -100,139 +120,165 @@ pub async fn land(
     // on the selected base (master or stacked-on Pull Request).
     let our_tree_oid = git.write_index(index)?;
 
-    // With that we construct the final version of the Pull Request, which will
-    // get landed. The contents of this commit (the tree) is what we produced by
-    // cherry-picking the local commit onto current master. The parents are the
-    // previous commit in the Pull Request branch and current master. Because
-    // current master is a parent of this commit, squash-merging this commit
-    // will give us essentially the cherry-picked commit on master, which is
-    // what we want.
-    let final_commit = git.create_derived_commit(
-        prepared_commit.oid,
-        "[𝘀𝗽𝗿] 𝘭𝘢𝘯𝘥𝘦𝘥 𝘷𝘦𝘳𝘴𝘪𝘰𝘯\n\n[skip ci]",
-        our_tree_oid,
-        &[pull_request.head_oid, current_master],
+    // Now let's predict what merging the PR into the master branch would
+    // produce.
+    let merge_index = git.repo().merge_commits(
+        &git.repo().find_commit(current_master)?,
+        &git.repo().find_commit(pull_request.head_oid)?,
+        None,
     )?;
 
-    // Update the Pull Request branch with the final commit
-    run_command(
-        async_process::Command::new("git")
-            .arg("push")
-            .arg("--no-verify")
-            .arg("--")
-            .arg(&config.remote_name)
-            .arg(format!(
-                "{}:refs/heads/{}",
-                final_commit,
-                get_branch_name_from_ref_name(&pull_request.head)?
-            )),
-    )
-    .await
-    .reword("git push failed".to_string())?;
-
-    // Update the Pull Request: set the base branch (that we are going to
-    // squash-merge into) to master. Depending on the contents of the Pull
-    // Request, the base branch may already be set to master, but we make this
-    // update unconditionally, because it has the positive side effect of making
-    // the actual merge below not fail. That's right, when the base was master
-    // already and I didn't make this call, the merge below would fail with
-    // "GitHub: Head branch was modified. Review and try the merge again". It
-    // may be a timing problem when the merge is happening *immediately* after
-    // updating the branch. This API call here also returns the updated Pull
-    // Request data, which might help settle the situation. With this API call
-    // in place, I have not seen the error once.
-    //
-    // PS: @jozef-mokry mentioned in code review that this is a known timing
-    // problem:
-    // https://github.community/t/merging-via-rest-api-returns-405-base-branch-was-modified-review-and-try-the-merge-again/13787
-    // TODO: implement retry loop around the merge instead
-    gh.update_pull_request(
-        pull_request_number,
-        PullRequestUpdate {
-            base: Some(config.master_ref.clone()),
-            ..Default::default()
-        },
-    )
-    .await?;
-
-    // We have the oven-ready to-be-merged commit (which is a direct child of
-    // current, or *very* recent master) on top of the head branch. Let's merge!
-    // Master may have been updated just now, so that our final version is not
-    // based on current master but an ancestor of that. That's fine, unless
-    // these new changes to master conflict with this Pull Request, in which
-    // case this merge will fail. Fair enough, we need the user to rebase on
-    // current master to deal with the conflicts.
-    let merge_result = octocrab::instance()
-        .pulls(&config.owner, &config.repo)
-        .merge(pull_request_number)
-        .method(octocrab::params::pulls::MergeMethod::Squash)
-        .title(pull_request.title)
-        .message(build_github_body_for_merging(&pull_request.sections))
-        .sha(format!("{}", final_commit))
-        .send()
-        .compat()
-        .await;
-    let success = match merge_result {
-        Ok(ref merge) => merge.merged,
-        Err(_) => false,
+    let merge_matches_cherrypick = if merge_index.has_conflicts() {
+        false
+    } else {
+        let merge_tree_oid = git.write_index(merge_index)?;
+        merge_tree_oid == our_tree_oid
     };
 
-    if success {
-        output("🛬", "Landed!")?;
-    } else {
-        output("❌", "GitHub Pull Request merge failed")?;
-
-        // This is the error we'll report
-        let mut error = Err(match merge_result {
-            Err(err) => err.into(),
-            Ok(merge) => {
-                merge.message.map(Error::new).unwrap_or_else(Error::empty)
-            }
-        });
-
-        // Let's try to undo the last bits, so the user can retry cleanly.
-        // First: set the Pull Request head to what it was (if it wasn't master)
-        if !base_is_master {
-            let result = gh
-                .update_pull_request(
-                    pull_request_number,
-                    PullRequestUpdate {
-                        base: Some(pull_request.base.clone()),
-                        ..Default::default()
-                    },
-                )
-                .await;
-            if let Err(e) = result {
-                error = error.context(format!("{}", e));
-            }
-        }
-
-        // Second: force-push the Pull Request branch to remove the final commit
-        // again
-        let git_push_failed = run_command(
-            async_process::Command::new("git")
-                .arg("push")
-                .arg("--no-verify")
-                .arg("--force")
-                .arg("--")
-                .arg(&config.remote_name)
-                .arg(format!(
-                    "{}:refs/heads/{}",
-                    pull_request.head_oid,
-                    get_branch_name_from_ref_name(&pull_request.head)?
-                )),
-        )
-        .await
-        .is_err();
-        if git_push_failed {
-            error = error.context("git push failed".to_string());
-        }
-
-        return error;
+    if !merge_matches_cherrypick {
+        return Err(Error::new(formatdoc!(
+            "This commit has been updated and/or rebased since the pull \
+             request was last updated. Please run `spr diff` to update the \
+             pull request and then try `spr land` again!"
+        )));
     }
 
-    // We know merge_result is Ok (we return above if it isn't)
-    let merge = merge_result.unwrap();
+    if !base_is_master {
+        // The base of the Pull Request on GitHub is not set to master. This
+        // means the Pull Request uses a base branch. We tested above that
+        // merging the Pull Request branch into the master branch produces the
+        // intended result (the same as cherry-picking the local commit onto
+        // master), so what we want to do is actually merge the Pull Request as
+        // it is into master. Hence, we change the base to the master branch.
+
+        gh.update_pull_request(
+            pull_request_number,
+            PullRequestUpdate {
+                base: Some(config.master_ref.clone()),
+                ..Default::default()
+            },
+        )
+        .await?;
+    }
+
+    // Check whether GitHub says this PR is mergeable. This happens in a
+    // retry-loop because recent changes to the Pull Request can mean that
+    // GitHub has not finished the mergeability check yet.
+    let mut attempts = 0;
+    let result = loop {
+        attempts += 1;
+
+        let mergeability = gh
+            .get_pull_request_mergeability(pull_request_number)
+            .await?;
+
+        if mergeability.head_oid != pull_request.head_oid {
+            break Err(Error::new(formatdoc!(
+                "The Pull Request seems to have been updated externally.
+                     Please try again!"
+            )));
+        }
+
+        if get_branch_name_from_ref_name(&mergeability.base).ok()
+            == Some(&config.master_branch)
+            && mergeability.mergeable.is_some()
+        {
+            if mergeability.mergeable != Some(true) {
+                break Err(Error::new(formatdoc!(
+                    "GitHub concluded the Pull Request is not mergeable at \
+                    this point. Please rebase your changes and try again!"
+                )));
+            }
+
+            if let Some(merge_commit) = mergeability.merge_commit {
+                git.fetch_commits_from_remote(
+                    &[merge_commit],
+                    &config.remote_name,
+                )
+                .await?;
+
+                if git.get_tree_oid_for_commit(merge_commit)? != our_tree_oid {
+                    return Err(Error::new(formatdoc!(
+                    "This commit has been updated and/or rebased since the pull
+                     request was last updated. Please run `spr diff` to update the pull
+                     request and then try `spr land` again!"
+                )));
+                }
+            };
+
+            break Ok(());
+        }
+
+        if attempts >= 10 {
+            // After ten failed attempts we give up.
+            break Err(Error::new(
+                "GitHub Pull Request did not update. Please try again!",
+            ));
+        }
+
+        // Wait one second before retrying
+        async_io::Timer::after(Duration::from_secs(1)).await;
+    };
+
+    let result = match result {
+        Ok(()) => {
+            // We have checked that merging the Pull Request branch into the master
+            // branch produces the intended result, and that's independent of whether we
+            // used a base branch with this Pull Request or not. We have made sure the
+            // target of the Pull Request is set to the master branch. So let GitHub do
+            // the merge now!
+            octocrab::instance()
+                .pulls(&config.owner, &config.repo)
+                .merge(pull_request_number)
+                .method(octocrab::params::pulls::MergeMethod::Squash)
+                .title(pull_request.title)
+                .message(build_github_body_for_merging(&pull_request.sections))
+                .sha(format!("{}", pull_request.head_oid))
+                .send()
+                .compat()
+                .await
+                .convert()
+                .and_then(|merge| {
+                    if merge.merged {
+                        Ok(merge)
+                    } else {
+                        Err(Error::new(formatdoc!(
+                            "GitHub Pull Request merge failed: {}",
+                            merge.message.unwrap_or_default()
+                        )))
+                    }
+                })
+        }
+        Err(err) => Err(err),
+    };
+
+    let merge = match result {
+        Ok(merge) => merge,
+        Err(mut error) => {
+            output("❌", "GitHub Pull Request merge failed")?;
+
+            // If we changed the target branch of the Pull Request earlier, then
+            // undo this change now.
+            if !base_is_master {
+                let result = gh
+                    .update_pull_request(
+                        pull_request_number,
+                        PullRequestUpdate {
+                            base: Some(pull_request.base.clone()),
+                            ..Default::default()
+                        },
+                    )
+                    .await;
+                if let Err(e) = result {
+                    error.push(format!("{}", e));
+                }
+            }
+
+            return Err(error);
+        }
+    };
+
+    output("🛬", "Landed!")?;
 
     let mut remove_old_branch_child_process =
         async_process::Command::new("git")
@@ -287,13 +333,11 @@ pub async fn land(
                 return Err(Error::new("git fetch failed"));
             }
         }
-        git.rebase_commits(
-            &mut prepared_commits[..],
-            git2::Oid::from_str(&sha)?,
-        )
-        .context(
-            "The automatic rebase failed - please rebase manually!".to_string(),
-        )?;
+        git.rebase_commits(&mut [prepared_commit], git2::Oid::from_str(&sha)?)
+            .context(
+                "The automatic rebase failed - please rebase manually!"
+                    .to_string(),
+            )?;
     }
 
     // Wait for the "git push" to delete the old Pull Request branch to finish,

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,6 +35,10 @@ impl Error {
     pub fn messages(&self) -> &Vec<String> {
         &self.messages
     }
+
+    pub fn push(&mut self, message: String) {
+        self.messages.push(message);
+    }
 }
 
 impl<E> From<E> for Error
@@ -75,7 +79,7 @@ impl<T> ResultExt for Result<T> {
 
     fn context(mut self, message: String) -> Self {
         if let Err(error) = &mut self {
-            error.messages.push(message);
+            error.push(message);
         }
 
         self
@@ -84,7 +88,7 @@ impl<T> ResultExt for Result<T> {
     fn reword(mut self, message: String) -> Self {
         if let Err(error) = &mut self {
             error.messages.pop();
-            error.messages.push(message);
+            error.push(message);
         }
 
         self

--- a/src/git.rs
+++ b/src/git.rs
@@ -195,6 +195,17 @@ impl Git {
         Ok(())
     }
 
+    pub fn head(&self) -> Result<Oid> {
+        let oid = self
+            .repo
+            .head()?
+            .resolve()?
+            .target()
+            .ok_or_else(|| Error::new("Cannot resolve HEAD"))?;
+
+        Ok(oid)
+    }
+
     pub fn resolve_reference(&self, reference: &str) -> Result<Oid> {
         let result =
             self.repo.find_reference(reference)?.peel_to_commit()?.id();

--- a/src/gql/pullrequest_mergeability_query.graphql
+++ b/src/gql/pullrequest_mergeability_query.graphql
@@ -1,0 +1,16 @@
+query PullRequestMergeabilityQuery(
+  $name: String!
+  $owner: String!
+  $number: Int!
+) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      baseRefName
+      headRefOid
+      mergeable
+      mergeCommit {
+        oid
+      }
+    }
+  }
+}


### PR DESCRIPTION
This commit contains are rework of the land command to a more straightforward implementation. The main point is to get rid of the additional commit `spr land` was producing on every land. That additional command was meant to control precisely what changes will hit the master branch when telling GitHub to merge. The intended side effect was that, much like Phabricator, any last-minute changes to the local commit would become part of the merged commit.
After using this for some time, we decided that being a bit more restrictive might be better here, even though we diverge from Phabricator's behaviour. If `spr land` finds that you have changed the contents of the commit since the last update, it will reject the land and instead tell you to retry after calling `spr diff` again.
This change should make it easier to audit changes that happen after a Pull Request was accepted, because we do not clutter the final history of the Pull Request with an additional commit that may or may not introduce changes.

Test Plan:
I have created branches with one and two commits on a test repo, and attempted to `spr land` with local changes, and it was always rejected. After `spr diff`, another call to `spr land` worked.
