### PR TITLE
Update handling of base branch

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -81,9 +81,27 @@ impl Config {
         existing_ref_names: &HashSet<String>,
         title: &str,
     ) -> String {
+        self.find_unused_branch_name(&existing_ref_names, &slugify(title))
+    }
+
+    pub fn get_base_branch_name(
+        &self,
+        existing_ref_names: &HashSet<String>,
+        title: &str,
+    ) -> String {
+        self.find_unused_branch_name(
+            &existing_ref_names,
+            &format!("{}/{}", &self.master_branch, &slugify(title)),
+        )
+    }
+
+    fn find_unused_branch_name(
+        &self,
+        existing_ref_names: &HashSet<String>,
+        slug: &str,
+    ) -> String {
         let remote_name = &self.remote_name;
         let branch_prefix = &self.branch_prefix;
-        let slug = slugify(title);
         let mut branch_name = format!("{branch_prefix}{slug}");
         let mut suffix = 0;
 
@@ -98,13 +116,6 @@ impl Config {
             suffix += 1;
             branch_name = format!("{branch_prefix}{slug}-{suffix}");
         }
-    }
-
-    pub fn get_base_branch_name(&self, pull_request_number: u64) -> String {
-        format!(
-            "{}{}/{}",
-            &self.branch_prefix, &self.master_branch, pull_request_number
-        )
     }
 }
 


### PR DESCRIPTION
Previously, the base branch name (when needed) was based on the pull
request number, which meant that it had to push the pull request with
the default base branch first, then get the pull request number, then
update it to change the base branch.  We found that didn't play nicely
with CODEOWNERS, which might trigger differently on the diff between
the revision and the default base branch than between the revision and
the pushed base branch.

Instead update things so the base branch name doesn't use the pull
request number, but uses the slug of the title instead, and set it on
the initial pull request creation.

Test Plan:
Created a commit on top of this one and used the new version to create
a PR.  It produced https://github.com/getcord/spr/pull/54, which has
the new format for the base branch name and doesn't have the base
branch changing post-creation.
