### PR TITLE
Fix `--update-message` option of `spr diff` when commit is unchanged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - register base branch at PR creation time instead of after
+- fix `--update-message` option of `spr diff` when invoked without making changes to the commit tree
 
 ### Security
 

--- a/src/github.rs
+++ b/src/github.rs
@@ -69,6 +69,22 @@ impl PullRequestUpdate {
     pub fn is_empty(&self) -> bool {
         self.title.is_none() && self.body.is_none() && self.base.is_none()
     }
+
+    pub fn update_message(
+        &mut self,
+        pull_request: &PullRequest,
+        message: &MessageSectionsMap,
+    ) {
+        let title = message.get(&MessageSection::Title);
+        if title.is_some() && title != Some(&pull_request.title) {
+            self.title = title.cloned();
+        }
+
+        let body = build_github_body(message);
+        if pull_request.body.as_ref() != Some(&body) {
+            self.body = Some(body);
+        }
+    }
 }
 
 #[derive(serde::Serialize, Default, Debug)]


### PR DESCRIPTION
@HenryDavies reported that the `--update-message` option of `spr diff` does not work. It looks like it only works when there were changes to the pull request (as in, the commit) to be submitted.
When the user only changes the commit message, but makes no changes to the code, `spr diff --update-message` should still update the message on GitHub (but not submit a new commit to the pull request branch).
This commit fixes this. The easiest way to fix this is to check whether `--update-message` was given when we do the early exit ("No update needed"), and then just update the message. This should be easier then getting rid of the early exit and then changing all the code below to not produce and push a commit, just so that the pull request update code that we already have (and that does update the message) is not skipped.
I moved some of the code into a new method on `PullRequestUpdate` to reduce code duplication.

Test Plan:
* submit this commit as pull request with an empty summary
* add the summary to the local commit's message
* run `spr diff --update-message`
* check that message was updated on GitHub
* add a line to the CHANGELOG for this fix, then update the local commit message, run `spr diff --update-message` again to see that it updates both PR contents and commit message on GitHub
