### PR TITLE
Add version number to `graphql_client` dependency for publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ serde = "^1.0.136"
 textwrap = "0.15.0"
 thiserror = "^1.0.30"
 unicode-normalization = "^0.1.19"
-graphql_client = { git = "https://github.com/graphql-rust/graphql-client", rev = "64ad4e34a6f9eb120ea83934bd68af18dbaf4a15" }
+graphql_client = { version = "0.10.0", git = "https://github.com/graphql-rust/graphql-client", rev = "64ad4e34a6f9eb120ea83934bd68af18dbaf4a15" }
 reqwest = { version = "^0.11", features = ["json"] }
 
 [dev-dependencies]


### PR DESCRIPTION
When publishing a crate, it cannot depend on unpublished crates. Currently, we depend on an unpublished version of `graphql_client` to avoid a security vulnerability.
Adding a version field to this dependency in `Cargo.toml` means that we use the patched version from Git when building, but the published version when publishing `spr` to crates.io.
This is not ideal, but the best we can do at this point. Hopefully, `graphql_client` will be updated on crates.io soon.

Fortunately, the binaries we produce for our homebrew tap will still be built with the fixed version. That's because the homebrew formula checks out the spr source code and builds it, which uses the fixed version.
Unfortunately, installing with `cargo install spr` will use the unfixed dependency. At least I think that's the case. I can only really test it after the next time we have published to crates.io.

Test Plan: `cargo check && cargo clippy && cargo package`
