### PR TITLE
Fix aborting pr update by entering empty message on prompt

### DIFF
--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -375,6 +375,7 @@ async fn diff_impl(
     if pull_request.is_some() && github_commit_message.is_none() {
         let input = dialoguer::Input::<String>::new()
             .with_prompt("Message (leave empty to abort)")
+            .allow_empty(true)
             .interact_text()?;
 
         if input.is_empty() {


### PR DESCRIPTION
When updating an existing PR with `spr diff`, spr will prompt for a message if one has not been provided using the `--message` option. The input prompt promises that an empty message will abort the update, but in fact spr just keeps prompting for a message.
This commit fixes that.

Test Plan:
submit this pull request, update it with `spr diff` with no message, abort by entering an empty message at the prompt.
