### PR TITLE
Do not enforce that pull requests have been approved on land

### DIFF
--- a/src/commands/land.rs
+++ b/src/commands/land.rs
@@ -69,13 +69,15 @@ pub async fn land(
     // Load Pull Request information
     let pull_request = gh.get_pull_request(pull_request_number).await??;
 
-    if config.require_approval && pull_request.state != PullRequestState::Open {
+    if pull_request.state != PullRequestState::Open {
         return Err(Error::new(formatdoc!(
             "This Pull Request is already closed!",
         )));
     }
 
-    if pull_request.review_status != Some(ReviewStatus::Approved) {
+    if config.require_approval
+        && pull_request.review_status != Some(ReviewStatus::Approved)
+    {
         return Err(Error::new(
             "This Pull Request has not been approved on GitHub.",
         ));

--- a/src/commands/land.rs
+++ b/src/commands/land.rs
@@ -11,7 +11,7 @@ use std::{io::Write, time::Duration};
 
 use crate::{
     error::{Error, Result, ResultExt},
-    github::{PullRequestState, PullRequestUpdate, ReviewStatus},
+    github::{PullRequestState, PullRequestUpdate},
     message::build_github_body_for_merging,
     output::{output, write_commit_title},
     utils::{get_branch_name_from_ref_name, run_command},
@@ -73,12 +73,6 @@ pub async fn land(
         return Err(Error::new(formatdoc!(
             "This Pull Request is already closed!",
         )));
-    }
-
-    if pull_request.review_status != Some(ReviewStatus::Approved) {
-        return Err(Error::new(
-            "This Pull Request has not been approved on GitHub.",
-        ));
     }
 
     output("🛫", "Getting started...")?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,6 +18,7 @@ pub struct Config {
     pub master_ref: String,
     pub remote_master_ref: String,
     pub branch_prefix: String,
+    pub require_approval: bool,
 }
 
 impl Config {
@@ -27,6 +28,7 @@ impl Config {
         remote_name: String,
         master_branch: String,
         branch_prefix: String,
+        require_approval: bool,
     ) -> Self {
         let remote_master_ref =
             format!("refs/remotes/{remote_name}/{master_branch}");
@@ -39,6 +41,7 @@ impl Config {
             master_ref,
             remote_master_ref,
             branch_prefix,
+            require_approval,
         }
     }
 
@@ -131,6 +134,7 @@ mod tests {
             "origin".into(),
             "master".into(),
             "spr/foo/".into(),
+            false,
         )
     }
 

--- a/src/spr.rs
+++ b/src/spr.rs
@@ -123,6 +123,8 @@ pub fn spr() -> Result<()> {
         .get_string("spr.githubMasterBranch")
         .unwrap_or_else(|_| "master".to_string());
     let branch_prefix = config.get_string("spr.branchPrefix")?;
+    let require_approval =
+        config.get_bool("spr.requireApproval").ok().unwrap_or(false);
 
     let config = crate::config::Config::new(
         github_owner,
@@ -130,6 +132,7 @@ pub fn spr() -> Result<()> {
         github_remote_name,
         github_master_branch,
         branch_prefix,
+        require_approval,
     );
 
     octocrab::initialise(


### PR DESCRIPTION
If you want that only approved pull requests can be landed, you should configure your GitHub repository accordingly.
We can remove the check in `spr`. If you attempt to land an unapproved pull request, spr will show you the error it got in response to the API merge command.
If you choose to not have this restricition in your repository, spr should allow you to land a pull request, even if it wasn't approved.

The old behaviour, where spr refuses to land an unapproved pr, can be restored by setting `git config spr.requireApproval true`.

Test Plan:
submit this commit for code review with `spr diff` and immediately try to `spr land`. The `spr` repository is configured on GitHub to require all changes to be approved, so `spr land` should show an error. Once this PR is approved, use `spr land` to merge.
