### PR TITLE
Add spr version number in PR commit messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [1.3.2] - 2022-06-16
+
+### Fixes
+
+- fix list of required GitHub permissions in `spr init` message
+- fix aborting Pull Request update by entering empty message on prompt
+- fix a problem where occasionally `spr diff` would fail because it could not push the base branch to GitHub
+
+### Improvements
+
+- add `spr.requireApprovals` config field to control if spr enforces that only accepted PRs can be landed
+- the spr binary no longer depends on openssl
+- add documentation to the docs/ folder
+- `spr diff` now warns the user if the local commit message differs from the one on GitHub when updating an existing Pull Request
+
 ## [1.3.1] - 2022-06-10
 
 ### Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1429,7 +1429,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spr"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "async-compat",
  "async-executor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spr"
-version = "1.3.1"
+version = "1.3.2"
 authors = ["Sven Over <sven@cord.com>", "Jozef Mokry <jozef@cord.com>"]
 description = "Submit pull requests for individual, amendable, rebaseable commits to GitHub"
 repository = "https://github.com/getcord/spr"

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -373,11 +373,15 @@ async fn diff_impl(
 
         Some(git.create_derived_commit(
             local_commit.parent_oid,
-            if pull_request.is_some() {
-                "[𝘀𝗽𝗿] 𝘤𝘩𝘢𝘯𝘨𝘦𝘴 𝘪𝘯𝘵𝘳𝘰𝘥𝘶𝘤𝘦𝘥 𝘵𝘩𝘳𝘰𝘶𝘨𝘩 𝘳𝘦𝘣𝘢𝘴𝘦\n\n[skip ci]"
-            } else {
-                "[𝘀𝗽𝗿] 𝘤𝘩𝘢𝘯𝘨𝘦𝘴 𝘵𝘰 𝘮𝘢𝘴𝘵𝘦𝘳 𝘵𝘩𝘪𝘴 𝘤𝘰𝘮𝘮𝘪𝘵 𝘪𝘴 𝘣𝘢𝘴𝘦𝘥 𝘰𝘯\n\n[skip ci]"
-            },
+            &format!(
+                "{}\n\nCreated using spr {}\n\n[skip ci]",
+                if pull_request.is_some() {
+                    "[𝘀𝗽𝗿] 𝘤𝘩𝘢𝘯𝘨𝘦𝘴 𝘪𝘯𝘵𝘳𝘰𝘥𝘶𝘤𝘦𝘥 𝘵𝘩𝘳𝘰𝘶𝘨𝘩 𝘳𝘦𝘣𝘢𝘴𝘦"
+                } else {
+                    "[𝘀𝗽𝗿] 𝘤𝘩𝘢𝘯𝘨𝘦𝘴 𝘵𝘰 𝘮𝘢𝘴𝘵𝘦𝘳 𝘵𝘩𝘪𝘴 𝘤𝘰𝘮𝘮𝘪𝘵 𝘪𝘴 𝘣𝘢𝘴𝘦𝘥 𝘰𝘯"
+                },
+                env!("CARGO_PKG_VERSION"),
+            ),
             new_base_tree,
             &parents[..],
         )?)
@@ -424,10 +428,14 @@ async fn diff_impl(
     // Create the new commit
     let pr_commit = git.create_derived_commit(
         local_commit.oid,
-        github_commit_message
-            .as_ref()
-            .map(|s| &s[..])
-            .unwrap_or("[𝘀𝗽𝗿] 𝘪𝘯𝘪𝘵𝘪𝘢𝘭 𝘷𝘦𝘳𝘴𝘪𝘰𝘯"),
+        &format!(
+            "{}\n\nCreated using spr {}",
+            github_commit_message
+                .as_ref()
+                .map(|s| &s[..])
+                .unwrap_or("[𝘀𝗽𝗿] 𝘪𝘯𝘪𝘵𝘪𝘢𝘭 𝘷𝘦𝘳𝘴𝘪𝘰𝘯"),
+            env!("CARGO_PKG_VERSION"),
+        ),
         new_head_tree,
         &pr_commit_parents[..],
     )?;


### PR DESCRIPTION
When we create commits for the branches we push to GitHub, they have one-line commit messages (plus `[skip ci]` for commits on the base branch).
This just adds a little meta data to those message. Specifically the version of spr that was used.

Test Plan:
`cargo check && cargo clippy && cargo build` and use the local build for submitting/updating/landing this pull request
