### PR TITLE
Bugfix: merge in master commit even if base tree didn't change

### DIFF
--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -411,7 +411,9 @@ async fn diff_impl(
     // commit is not directly based on master, we have to create this new PR
     // with a base branch, so that is case 3.
 
-    let (pr_base_parent, base_branch) = if pr_base_tree == new_base_tree {
+    let (pr_base_parent, base_branch) = if pr_base_tree == new_base_tree
+        && !needs_merging_master
+    {
         // Case 1
         (None, base_branch)
     } else if base_branch.is_none()


### PR DESCRIPTION
When updating an existing pull request, we need to merge in the master commit if the local commit has been rebased.
It can happen that the local commit has been rebased, but the commit's parent's tree has not changed. E.g. for the second of two commits, when the first one gets landed. The second is still based on the first, but that first commit is now on master. So we are based on a different master commit, even though the tree of the commit's parent hasn't changed.
In this situation we still need to merge in master. Not to bring in any changes, but to correct the topology. It is important that the pull request branch is based on the same master commit as the local commit.

Test Plan:
* I created a local branch on master, added two commits with independent changes.
* `spr diff --all` to create Pull Requests for both
* using `git rebase -i`, I landed the first commit (I put `x spr land` in a line after the first commit)
* after that the branch now contains only the second commit, and is based on the landed first commit in master
* I call `spr diff` to update the second commit
Without the changes in this PR, a new commit is added to the PR branch, but master is not merged in and no base-branch commit is added.
With this PR: a new base branch commit correclty merges in master, and the PR branch merges in the new base branch commit
