### PR TITLE
Add items to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - get rid of italics in generated commit messages - they're silly
 - fix creation of unneccessary creation of base branches when updating PRs
+- when updating an existing PR, merge in master commit if the commit was rebased even if the base tree did not change
+- add a final rebase commit to the PR branch when landing and it is necessary to do so to not have changes in the base of this commit, that since have landed on master, displayed as part of this PR
 
 ### Improvemets
 


### PR DESCRIPTION
I only just landed #89 and #90 and felt instant regret because I once again forgot to add the corresponding items to the CHANGELOG before landing.

Test Plan: read
