### PR TITLE
Release version 1.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Changelog
 
-## [Unreleased]
+## [1.3.3] - 2022-06-27
 
 ### Fixes
 
 - get rid of italics in generated commit messages - they're silly
-- fix creation of unneccessary creation of base branches when updating PRs
+- fix unneccessary creation of base branches when updating PRs
 - when updating an existing PR, merge in master commit if the commit was rebased even if the base tree did not change
 - add a final rebase commit to the PR branch when landing and it is necessary to do so to not have changes in the base of this commit, that since have landed on master, displayed as part of this PR
 
@@ -112,3 +112,4 @@
 [1.3.0]: https://github.com/getcord/spr/releases/tag/v1.3.0
 [1.3.1]: https://github.com/getcord/spr/releases/tag/v1.3.1
 [1.3.2]: https://github.com/getcord/spr/releases/tag/v1.3.2
+[1.3.3]: https://github.com/getcord/spr/releases/tag/v1.3.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1396,7 +1396,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spr"
-version = "1.3.3-beta.1"
+version = "1.3.3"
 dependencies = [
  "async-compat",
  "async-executor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spr"
-version = "1.3.3-beta.1"
+version = "1.3.3"
 authors = ["Sven Over <sven@cord.com>", "Jozef Mokry <jozef@cord.com>"]
 description = "Submit pull requests for individual, amendable, rebaseable commits to GitHub"
 repository = "https://github.com/getcord/spr"

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -380,9 +380,10 @@ async fn diff_impl(
     // If it's `None`, then we will not merge anything into the new Pull Request
     // commit.
     // If we are updating an existing PR, then there are three cases here:
-    // (1) the parent tree of this commit is unchanged, which means that the
-    //     local commit was amended, but not rebased. We don't need to merge
-    //     anything into the Pull Request branch.
+    // (1) the parent tree of this commit is unchanged and we do not need to
+    //     merge in master, which means that the local commit was amended, but
+    //     not rebased. We don't need to merge anything into the Pull Request
+    //     branch.
     // (2) the parent tree has changed, but the parent of the local commit is on
     //     master (or we are cherry-picking) and we are not already using a base
     //     branch: in this case we can merge the master commit we are based on


### PR DESCRIPTION
This also contains a typo fix in the changelog, plus one extended comment in `diff.rs` that I forgot to save before.

Test Plan: `cargo run -- --version`, `cargo package`
