### PR TITLE
Add installation instructions for Nix to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,19 @@ spr is pronounced /ˈsuːpəɹ/, like the English word 'super'.
 brew install getcord/tap/spr
 ```
 
+#### Using Nix
+
+```shell
+nix-channel --update && nix-env -i spr
+```
+
 #### Using Cargo
 
-If you have Cargo installed (the Rust build tool), you can install spr by running `cargo install spr`.
+If you have Cargo installed (the Rust build tool), you can install spr by running
+
+```shell
+cargo install spr
+```
 
 ### Install from Source
 


### PR DESCRIPTION
spr is now listed in nixpkgs! This means that both people who use Nix for package management on Mac, and users of NixOS (Linux) can just install spr.

Test Plan:
```
docker run --rm=true -it nixos/nix
nix-channel --update && nix-env -i spr
spr --version
```
