### PR TITLE
Delete CLI docs page

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -20,4 +20,3 @@
 # Reference Guide
 
 - [Configuration](reference/configuration.md)
-- [Command Line Options](reference/cli.md)

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,3 +1,0 @@
-# Command Line Options
-
-## TO BE WRITTEN...


### PR DESCRIPTION
As discussed, I don't think it's necessary. The global options that
override config values are documented on the Configuration page, and
it doesn't seem useful to me to duplicate `spr help`'s documentation
of the individual commands' options on here.

Test Plan: look
