### PR TITLE
Turn on curly quotes for docs site

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -12,3 +12,4 @@ build-dir = "book"
 git-repository-url = "https://github.com/getcord/spr"
 edit-url-template = "https://github.com/getcord/spr/edit/master/{path}"
 site-url = "/spr/"
+curly-quotes = true


### PR DESCRIPTION
Feel free to say no to this; I just think it looks better. As well as
generating curly quotes (outside of code blocks of course), it also
turns `---` into em dashes and `...` into ellipsis characters.

Test Plan: run build and look at apostrophes in the text
