### PR TITLE
Write the intro, and clean up the table of contents

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,8 +2,51 @@
 
 # Introduction
 
-spr is a command line tool for using a stacked diff workflow with GitHub.
+spr is a command line tool for using a stacked-diff workflow with GitHub.
 
-You do not need to have a dedicated branch in your local repository for each pull request. Instead, spr can create a pull request for an individual local commit. You can then amend and/or rebase this commit and update the pull request using spr. And finally, spr can assist you with merging the commit. It always uses "squash-merges" on GitHub, which means that the commit you worked on locally now materialises as a single commit on your centrally shared branch (traditionally called "master", or "main").
+The idea behind spr is that your local branch management should not be dictated by your code-review tool. You should be able to send out code for review in individual commits, not branches. You make branches only when you want to, not because you _have_ to for every code review.
 
-spr is heavily inspired by Phabricator, both in terms of the workflow it enables you to use, and also in terms of the terminology used ("diff", "land", etc.). If you have previously used Phabricator, you should have very little problems using spr to work with GitHub.
+If you've used Phabricator and its command-line tool `arc`, you'll find spr very familiar.
+
+To get started, see the [installation instructions](./user/installation.md), and the [first-time setup](./user/setup.md). (You'll need to go through setup in each repo where you want to use spr.)
+
+## Workflow overview
+
+In spr's workflow, you send out individual commits for review, not entire branches. This is the most basic version:
+
+1. Make your change as a single commit, directly on your local `main`[^master] branch.
+
+2. Run `spr diff` to send out your commit for review on GitHub.
+
+3. If you need to make updates in response to feedback, amend your commit, and run `spr diff` again to send those updates to GitHub.
+
+4. Once reviewers have approved, run `spr land` to push your commit upstream.
+
+In practice, you're likely to have more complex situations: multiple commits being reviewed, and possibly in-review commits that depend on others. You may need to make updates to any of these commits, or land them in any order.
+
+spr can handle all of that, without requiring any particular way of organizing your local repo. See the guides in the "How To" section for instructions on using spr in those situations:
+
+- [Simple PRs](./user/simple.md): no more than one review in flight on any branch.
+- [Stacked PRs](./user/stack.md): multiple reviews in flight at once on your local `main`.
+
+## Rationale
+
+The reason to use spr is that it allows you to use whatever local branching scheme you want, instead of being forced to create a branch for every review. In particular, you can commit everything directly on your local `main`. This greatly simplifies rebasing: rather than rebasing every review branch individually, you can simply rebase your local `main` onto upstream `main`.
+
+You can make branches locally if you want, and it's not uncommon for spr users to do so. You could even make a branch for every review if you don't want to use the stacked-PR workflow. It doesn't matter to spr.
+
+One reasonable position is to make small changes directly on `main`, but make branches for larger, more complex changes. The branch keeps the work-in-progress isolated while you get it to a reviewable state, making lots of small commits that aren't individually reviewable. Once the branch as a whole is reviewable, you can squash it down to a single commit, which you can send out for review (either from the branch or cherry-picked onto `main`).
+
+### Why Review Commits?
+
+The principle behind spr is **one commit per logical change**. Each commit should be able to stand on its own: it should have a coherent thesis and be a complete change in and of itself. It should have a clear summary, description, and test plan. It should leave the codebase in a consistent state: building and passing tests, etc.
+
+In addition, ideally, it shouldn't be possible to further split a commit into multiple commits that each stand on their own. If you _can_ split a commit that way, you should.
+
+What follows from those principles is the idea that **commits, not branches, should be the unit of code review**. The above description of a commit also describes the ideal code review: a single, well-described change that leaves the codebase in a consistent state, and that cannot be subdivided further.
+
+If the commit is the unit of code review, then, why should the code review tool require that you make branches? spr's answer is: it shouldn't.
+
+Following the one-commit-per-change principle maintains the invariant that checking out any commit on `main` gives you a codebase that has been reviewed _in that state_, and that builds and passes tests, etc. This makes it easy to revert changes, and to bisect.
+
+[^master]: Git's default branch name is `master`, but GitHub's is now `main`, so we'll use `main` throughout this documentation.

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -2,13 +2,10 @@
 
 [Introduction](README.md)
 
-# User Guide
+# Getting Started
 
 - [Installation](user/installation.md)
 - [Set up spr](user/setup.md)
-- [Create a Pull Request](user/create.md)
-- [Update a Pull Request](user/update.md)
-- [Merge a Pull Request](user/merge.md)
 
 # How To
 

--- a/docs/user/create.md
+++ b/docs/user/create.md
@@ -1,5 +1,0 @@
-# Create a Pull Request
-
-## TO BE WRITTEN...
-
-The gist: run `spr diff`

--- a/docs/user/merge.md
+++ b/docs/user/merge.md
@@ -1,5 +1,0 @@
-# Merge a Pull Request
-
-## TO BE WRITTEN...
-
-The gist: run `spr land`

--- a/docs/user/setup.md
+++ b/docs/user/setup.md
@@ -1,5 +1,17 @@
 # Set up spr
 
-## TO BE WRITTEN...
+In the repo you want to use spr in, run `spr init`; this will ask you several questions.
 
-The gist: run `spr init` and follow instructions
+You'll need to provide a GitHub personal access token (PAT) as the first step. [See the GitHub docs](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) on how to create one. `spr init` will tell you which scopes the token must have; make sure to set them correctly when creating the token.
+
+The rest of the settings that `spr init` asks for have sensible defaults, so almost all users can simply accept the defaults. The most common situation where you would need to diverge from the defaults is if the remote representing GitHub is not called `origin`.
+
+See the [Configuration](./reference/configuration.md) reference page for full details about the available settings.
+
+After initial setup, you can update your settings in several ways:
+
+- Simply rerun `spr init`. The defaults it suggests will be your existing settings, so you can easily change only what you need to.
+
+- Use `git config --set` ([docs here](https://git-scm.com/docs/git-config)).
+
+- Edit the `[spr]` section of `.git/config` directly.

--- a/docs/user/update.md
+++ b/docs/user/update.md
@@ -1,5 +1,0 @@
-# Update a Pull Request
-
-## TO BE WRITTEN...
-
-The gist: run `spr diff`


### PR DESCRIPTION
The intro gives a super quick overview of how the workflow looks, and
explains why you might want to use spr.

The actual setup instructions are moved to a separate page and
expanded a bit.

Finally, this removes the unused pages from the table of contents and
deletes their files.

Test Plan: look at the whole site in a browser.
