### PR TITLE
Fix tests and clippy warnings

### DIFF
--- a/src/commands/amend.rs
+++ b/src/commands/amend.rs
@@ -60,7 +60,7 @@ pub async fn amend(
             let pull_request = pull_request.await??;
             commit.message = pull_request.sections;
         }
-        failure = validate_commit_message(&commit.message, &config).is_err()
+        failure = validate_commit_message(&commit.message, config).is_err()
             || failure;
     }
     git.rewrite_commit_messages(slice, None)?;

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -194,7 +194,7 @@ async fn diff_impl(
     }
 
     if local_commit.pull_request_number.is_none() || opts.update_message {
-        validate_commit_message(message, &config)?;
+        validate_commit_message(message, config)?;
     }
 
     // Load Pull Request information

--- a/src/commands/format.rs
+++ b/src/commands/format.rs
@@ -42,7 +42,7 @@ pub async fn format(
 
     for commit in slice.iter() {
         write_commit_title(commit)?;
-        failure = validate_commit_message(&commit.message, &config).is_err()
+        failure = validate_commit_message(&commit.message, config).is_err()
             || failure;
     }
     git.rewrite_commit_messages(slice, None)?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -155,6 +155,7 @@ mod tests {
             "master".into(),
             "spr/foo/".into(),
             false,
+            true,
         )
     }
 


### PR DESCRIPTION
We have a few clippy warnings and one test has a build error after landing #100.
Our on-pull-request CI job does not run on pull request coming in from forks. That's why it could sneak in unnoticed.
This commit fixes the issues in the code.
I checked GitHub documentation: when we have pull requests incoming from forks, we need to approve workflow runs. When we get PRs from outside collaborator, we should quickly check that they do not make changes to our GitHub workflows, and then it's safe to approve workflow runs on the PR page.

Test Plan: `cargo check && cargo test && cargo clippy && cargo build`
