### PR TITLE
Don't fail on requesting reviewers

### DIFF
--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -643,8 +643,18 @@ async fn diff_impl(
 
         message.insert(MessageSection::PullRequest, pull_request_url);
 
-        gh.request_reviewers(pull_request_number, requested_reviewers)
-            .await?;
+        let result = gh
+            .request_reviewers(pull_request_number, requested_reviewers)
+            .await;
+        match result {
+            Ok(()) => (),
+            Err(error) => {
+                output("⚠️", "Requesting reviewers failed")?;
+                for message in error.messages() {
+                    output("  ", message)?;
+                }
+            }
+        }
     }
 
     Ok(())


### PR DESCRIPTION
It's not always possible to request reviewers, so we don't always fail.

Unless you have write access to a repo, you cannot request reviewers for
a PR. Since there are workflows where not everyone has write access, and
we don't want to fail unnecessarily, we don't make it a requirement that
requesting reviewers has to succeed.

This was first raised in https://github.com/getcord/spr/issues/97, and
the resolution to only communicate a warning was brought up in
https://github.com/getcord/spr/pull/109#discussion_r917668718.

Should close https://github.com/getcord/spr/issues/97.

Test Plan:
1. First, ensure you don't have write access to a repo.
1. Create a commit.
1. Run `spr diff`
1. [ ] The PR should be opened and the command should only warn when it
    cannot request reviewers.
