### PR TITLE
Update installation instructions (spr is now in homebrew!)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Comprehensive documentation is available here: https://getcord.github.io/spr/
 #### Using Homebrew
 
 ```shell
-brew install getcord/tap/spr
+brew install spr
 ```
 
 #### Using Nix

--- a/docs/user/installation.md
+++ b/docs/user/installation.md
@@ -5,7 +5,13 @@
 ### Using Homebrew
 
 ```shell
-brew install getcord/tap/spr
+brew install spr
+```
+
+### Using Nix
+
+```shell
+nix-channel --update && nix-env -i spr
 ```
 
 ### Using Cargo


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-core/pull/106077 was accepted and spr is now listed in homebrew's core formulas.

This commit updates the installation instructions, which includes adding Nix to `docs/user/installation.md`.

Test Plan:
`brew install spr` (I ran it inside a fresh Docker container, started with `docker run --rm=true -it homebrew/brew`)
