### PR TITLE
[easy] Disable terminal text wrapping if message contains URL

### DIFF
--- a/spr/src/output.rs
+++ b/spr/src/output.rs
@@ -13,9 +13,16 @@ pub fn output(icon: &str, text: &str) -> Result<()> {
     let bullet = format!("  {}  ", icon);
     let indent = console::measure_text_width(&bullet);
     let indent_string = " ".repeat(indent);
-    let options = textwrap::Options::new((term.size().1 as usize) - indent * 2)
-        .initial_indent(&bullet)
-        .subsequent_indent(&indent_string);
+    let mut options =
+        textwrap::Options::new((term.size().1 as usize) - indent * 2)
+            .initial_indent(&bullet)
+            .subsequent_indent(&indent_string);
+
+    if lazy_regex::regex_is_match!(r#"https?://"#, text) {
+        options.break_words = false;
+        options.word_separator = textwrap::WordSeparator::AsciiSpace;
+        options.word_splitter = textwrap::WordSplitter::NoHyphenation;
+    }
 
     term.write_line(&textwrap::wrap(text.trim(), &options).join("\n"))?;
     Ok(())

--- a/spr/src/output.rs
+++ b/spr/src/output.rs
@@ -13,16 +13,12 @@ pub fn output(icon: &str, text: &str) -> Result<()> {
     let bullet = format!("  {}  ", icon);
     let indent = console::measure_text_width(&bullet);
     let indent_string = " ".repeat(indent);
-    let mut options =
-        textwrap::Options::new((term.size().1 as usize) - indent * 2)
-            .initial_indent(&bullet)
-            .subsequent_indent(&indent_string);
-
-    if lazy_regex::regex_is_match!(r#"https?://"#, text) {
-        options.break_words = false;
-        options.word_separator = textwrap::WordSeparator::AsciiSpace;
-        options.word_splitter = textwrap::WordSplitter::NoHyphenation;
-    }
+    let options = textwrap::Options::new((term.size().1 as usize) - indent * 2)
+        .initial_indent(&bullet)
+        .subsequent_indent(&indent_string)
+        .break_words(false)
+        .word_separator(textwrap::WordSeparator::AsciiSpace)
+        .word_splitter(textwrap::WordSplitter::NoHyphenation);
 
     term.write_line(&textwrap::wrap(text.trim(), &options).join("\n"))?;
     Ok(())


### PR DESCRIPTION
### Summary

Minor issue: by default `textwrap` can break a URL into multiple lines. This makes PR links unclickable when the terminal window is small.

I played with a few config options on https://mgeisler.github.io/textwrap/ — think this is the best combo?

<img width="600" alt="image" src="https://user-images.githubusercontent.com/2268452/186331956-5b183ff6-6b3f-4ac3-82e8-72d2044abda8.png">


### Test Plan

| Before  | After |
| ------------- | ------------- |
| <img width="491" alt="Screen Shot 2022-08-23 at 9 44 16 PM" src="https://user-images.githubusercontent.com/2268452/186331402-0943f667-6a9f-4c2f-8961-b12997c12b6b.png"> | <img width="491" alt="Screen Shot 2022-08-23 at 9 45 12 PM" src="https://user-images.githubusercontent.com/2268452/186331444-984aeecb-30df-4f59-b84b-0a7735d80bfb.png"> |