### PR TITLE
Use branch_name for base branch in github

### DIFF
--- a/spr/src/commands/diff.rs
+++ b/spr/src/commands/diff.rs
@@ -579,7 +579,7 @@ async fn diff_impl(
             // change that now.
             if pull_request.base.branch_name() != base_branch.branch_name() {
                 pull_request_updates.base =
-                    Some(base_branch.on_github().to_string());
+                    Some(base_branch.branch_name().to_string());
             }
         } else {
             // The Pull Request is against the master branch. In that case we
@@ -620,7 +620,7 @@ async fn diff_impl(
                     .unwrap_or(&config.master_ref)
                     .branch_name()
                     .to_string(),
-                pull_request_branch.on_github().to_string(),
+                pull_request_branch.branch_name().to_string(),
                 opts.draft,
             )
             .await?;

--- a/spr/src/commands/diff.rs
+++ b/spr/src/commands/diff.rs
@@ -618,7 +618,7 @@ async fn diff_impl(
                 base_branch
                     .as_ref()
                     .unwrap_or(&config.master_ref)
-                    .on_github()
+                    .branch_name()
                     .to_string(),
                 pull_request_branch.on_github().to_string(),
                 opts.draft,

--- a/spr/src/commands/land.rs
+++ b/spr/src/commands/land.rs
@@ -231,7 +231,7 @@ pub async fn land(
         gh.update_pull_request(
             pull_request_number,
             PullRequestUpdate {
-                base: Some(config.master_ref.on_github().to_string()),
+                base: Some(config.master_ref.branch_name().to_string()),
                 ..Default::default()
             },
         )


### PR DESCRIPTION
Previously the base branch in the API was `refs/head/master` but Github's branch protection seems to break with this form. If it's simply `master` it seems to work as intended.

Fixes: https://github.com/getcord/spr/issues/108

Test Plan: Several folks at my company have been using this fork for several days without running into #108 again.
