### PR TITLE
Change PR list output for CHANGES_REQUESTED

### DIFF
--- a/spr/src/commands/list.rs
+++ b/spr/src/commands/list.rs
@@ -58,7 +58,7 @@ fn print_pr_info(
             }
             Some(
                 search_query::PullRequestReviewDecision::CHANGES_REQUESTED,
-            ) => console::style("Rejected").red(),
+            ) => console::style("Changes Needed").red(),
             None
             | Some(search_query::PullRequestReviewDecision::REVIEW_REQUIRED) => {
                 console::style("Pending")

--- a/spr/src/commands/list.rs
+++ b/spr/src/commands/list.rs
@@ -58,7 +58,7 @@ fn print_pr_info(
             }
             Some(
                 search_query::PullRequestReviewDecision::CHANGES_REQUESTED,
-            ) => console::style("Changes Needed").red(),
+            ) => console::style("Changes Requested").red(),
             None
             | Some(search_query::PullRequestReviewDecision::REVIEW_REQUIRED) => {
                 console::style("Pending")


### PR DESCRIPTION
When changes are requested, SPR shows those changes are rejected, which
is a little stronger of wording than reality.

