### PR TITLE
Allow for --all to have shorthand

### DIFF
--- a/spr/src/commands/amend.rs
+++ b/spr/src/commands/amend.rs
@@ -14,8 +14,8 @@ use crate::{
 
 #[derive(Debug, clap::Parser)]
 pub struct AmendOptions {
-    /// format all commits in branch, not just HEAD
-    #[clap(long)]
+    /// Amend all commits in branch, not just HEAD
+    #[clap(long, short = 'a')]
     all: bool,
 }
 

--- a/spr/src/commands/close.rs
+++ b/spr/src/commands/close.rs
@@ -20,7 +20,7 @@ use crate::{
 #[derive(Debug, clap::Parser)]
 pub struct CloseOptions {
     /// Close Pull Requests for the whole branch, not just the HEAD commit
-    #[clap(long)]
+    #[clap(long, short = 'a')]
     all: bool,
 }
 

--- a/spr/src/commands/diff.rs
+++ b/spr/src/commands/diff.rs
@@ -24,7 +24,7 @@ use indoc::{formatdoc, indoc};
 #[derive(Debug, clap::Parser)]
 pub struct DiffOptions {
     /// Create/update pull requests for the whole branch, not just the HEAD commit
-    #[clap(long)]
+    #[clap(long, short = 'a')]
     all: bool,
 
     /// Update the pull request title and description on GitHub from the local

--- a/spr/src/commands/format.rs
+++ b/spr/src/commands/format.rs
@@ -14,7 +14,7 @@ use crate::{
 #[derive(Debug, clap::Parser)]
 pub struct FormatOptions {
     /// format all commits in branch, not just HEAD
-    #[clap(long)]
+    #[clap(long, short = 'a')]
     all: bool,
 }
 


### PR DESCRIPTION
I frequently am using `spr diff --all` and have a larger stack of changes. It'd be nice to have this shorthand, which is similar to `git commit -a`.
