### PR TITLE
Don't fetch all users/teams to check reviewers

### DIFF
--- a/spr/src/commands/diff.rs
+++ b/spr/src/commands/diff.rs
@@ -12,7 +12,7 @@ use crate::{
     git::PreparedCommit,
     github::{
         PullRequest, PullRequestRequestReviewers, PullRequestState,
-        PullRequestUpdate,
+        PullRequestUpdate, GitHub
     },
     message::{validate_commit_message, MessageSection},
     output::{output, write_commit_title},
@@ -231,35 +231,42 @@ async fn diff_impl(
 
     if local_commit.pull_request_number.is_none() {
         if let Some(reviewers) = message.get(&MessageSection::Reviewers) {
-            let eligible_reviewers = gh.get_reviewers().await?;
-
             let reviewers = parse_name_list(reviewers);
             let mut checked_reviewers = Vec::new();
 
             for reviewer in reviewers {
-                if let Some(entry) = eligible_reviewers.get(&reviewer) {
-                    if let Some(slug) = reviewer.strip_prefix('#') {
+                // Teams are indicated with a leading #
+                if let Some(slug) = reviewer.strip_prefix('#') {
+                    if let Ok(team) = GitHub::get_github_team((&config.owner).into(), slug.into()).await {
                         requested_reviewers
                             .team_reviewers
-                            .push(slug.to_string());
-                    } else {
-                        requested_reviewers.reviewers.push(reviewer.clone());
-                    }
+                            .push(team.slug.to_string());
 
-                    if let Some(name) = entry {
-                        checked_reviewers.push(format!(
-                            "{} ({})",
-                            reviewer,
-                            remove_all_parens(name)
-                        ));
-                    } else {
                         checked_reviewers.push(reviewer);
+                    } else {
+                        return Err(Error::new(format!(
+                            "Reviewers field contains unknown team '{}'",
+                            reviewer
+                        )));
                     }
                 } else {
-                    return Err(Error::new(format!(
-                        "Reviewers field contains unknown user/team '{}'",
-                        reviewer
-                    )));
+                    if let Ok(user) = GitHub::get_github_user(reviewer.clone()).await {
+                        requested_reviewers.reviewers.push(user.login);
+                        if let Some(name) = user.name {
+                            checked_reviewers.push(format!(
+                                "{} ({})",
+                                reviewer.clone(),
+                                remove_all_parens(&name)
+                            ));
+                        } else {
+                            checked_reviewers.push(reviewer);
+                        }
+                    } else {
+                        return Err(Error::new(format!(
+                            "Reviewers field contains unknown user '{}'",
+                            reviewer
+                        )));
+                    }
                 }
             }
 

--- a/spr/src/github.rs
+++ b/spr/src/github.rs
@@ -143,11 +143,19 @@ impl GitHub {
         }
     }
 
-    async fn get_github_user(login: String) -> Result<UserWithName> {
+    pub async fn get_github_user(login: String) -> Result<UserWithName> {
         octocrab::instance()
             .get::<UserWithName, _, _>(format!("users/{}", login), None::<&()>)
             .await
             .map_err(Error::from)
+    }
+
+    pub async fn get_github_team(owner: String, team: String) -> Result<octocrab::models::teams::Team> {
+        octocrab::instance()
+          .teams(owner)
+          .get(team)
+          .await
+          .map_err(Error::from)
     }
 
     pub async fn get_pull_request(self, number: u64) -> Result<PullRequest> {
@@ -372,60 +380,6 @@ impl GitHub {
             .await?;
 
         Ok(())
-    }
-
-    pub async fn get_reviewers(
-        &self,
-    ) -> Result<HashMap<String, Option<String>>> {
-        let github = self.clone();
-
-        let (users, teams): (
-            Vec<UserWithName>,
-            octocrab::Page<octocrab::models::teams::RequestedTeam>,
-        ) = futures_lite::future::try_zip(
-            async {
-                let users = octocrab::instance()
-                    .get::<Vec<octocrab::models::User>, _, _>(
-                        format!(
-                            "repos/{}/{}/collaborators",
-                            &github.config.owner, &github.config.repo
-                        ),
-                        None::<&()>,
-                    )
-                    .await?;
-
-                let user_names = futures::future::join_all(
-                    users.into_iter().map(|u| GitHub::get_github_user(u.login)),
-                )
-                .await
-                .into_iter()
-                .collect::<Result<Vec<_>>>()?;
-
-                Ok::<_, Error>(user_names)
-            },
-            async {
-                Ok(octocrab::instance()
-                    .teams(&github.config.owner)
-                    .list()
-                    .send()
-                    .await
-                    .ok()
-                    .unwrap_or_default())
-            },
-        )
-        .await?;
-
-        let mut map = HashMap::new();
-
-        for user in users {
-            map.insert(user.login, user.name);
-        }
-
-        for team in teams {
-            map.insert(format!("#{}", team.slug), team.description);
-        }
-
-        Ok::<_, Error>(map)
     }
 
     pub async fn get_pull_request_mergeability(


### PR DESCRIPTION
Prior to this PR, reviewers were validated by first fetching all teams and users, and then checking membership in that result. This suffers from a few issues:

- it was broken since it seemed to only fetch one page, not all pages. This can't work with any significant number of users or teams in an organization.
- it is inefficient
  - fetching the full list is not necessary
  - there was a 1+n style query, where the users name would be looked for each user in the list.

This PR modifies reviewer validation by fetching only the users/teams specified in the commit.