### PR TITLE
Use octocrab for GraphQL queries

### DIFF
--- a/spr/src/commands/list.rs
+++ b/spr/src/commands/list.rs
@@ -8,7 +8,6 @@
 use crate::error::Error;
 use crate::error::Result;
 use graphql_client::{GraphQLQuery, Response};
-use reqwest;
 
 #[allow(clippy::upper_case_acronyms)]
 type URI = String;
@@ -21,7 +20,6 @@ type URI = String;
 pub struct SearchQuery;
 
 pub async fn list(
-    graphql_client: reqwest::Client,
     config: &crate::config::Config,
 ) -> Result<()> {
     let variables = search_query::Variables {
@@ -31,13 +29,9 @@ pub async fn list(
         ),
     };
     let request_body = SearchQuery::build_query(variables);
-    let res = graphql_client
-        .post("https://api.github.com/graphql")
-        .json(&request_body)
-        .send()
+    let response_body: Response<search_query::ResponseData> = octocrab::instance()
+        .post("graphql",Some(&request_body))
         .await?;
-    let response_body: Response<search_query::ResponseData> =
-        res.json().await?;
 
     print_pr_info(response_body).ok_or_else(|| Error::new("unexpected error"))
 }

--- a/spr/src/main.rs
+++ b/spr/src/main.rs
@@ -172,14 +172,9 @@ pub async fn spr() -> Result<()> {
         format!("Bearer {}", github_auth_token).parse()?,
     );
 
-    let graphql_client = reqwest::Client::builder()
-        .default_headers(headers)
-        .build()?;
-
     let mut gh = spr::github::GitHub::new(
         config.clone(),
         git.clone(),
-        graphql_client.clone(),
     );
 
     match cli.command {
@@ -192,7 +187,7 @@ pub async fn spr() -> Result<()> {
         Commands::Amend(opts) => {
             commands::amend::amend(opts, &git, &mut gh, &config).await?
         }
-        Commands::List => commands::list::list(graphql_client, &config).await?,
+        Commands::List => commands::list::list(&config).await?,
         Commands::Patch(opts) => {
             commands::patch::patch(opts, &git, &mut gh, &config).await?
         }


### PR DESCRIPTION
Remove the manual use of reqwest::Client for graphql queries and use octocrab instead.

This removes the need to specify the github api base url multiple times. We instead leverage the global octocrab instance for which we configure the api base url once.

This is beneficial for a cleaner implementation of Github Enterprise support (#158), as we can configure the base url once.