### PR TITLE
Update regex to match periods in GitHub URL

### DIFF
--- a/spr/src/config.rs
+++ b/spr/src/config.rs
@@ -66,7 +66,7 @@ impl Config {
         }
 
         let regex = lazy_regex::regex!(
-            r#"^\s*https?://github.com/([\w\-]+)/([\w\-]+)/pull/(\d+)([/?#].*)?\s*$"#
+            r#"^\s*https?://github.com/([\w\-\.]+)/([\w\-\.]+)/pull/(\d+)([/?#].*)?\s*$"#
         );
         let m = regex.captures(text);
         if let Some(caps) = m {


### PR DESCRIPTION
This fixes the issue described in #193 .

`spr` in the following screenshot is the current `spr` release (v1.3.5). `_spr` is the binary compiled with the proposed change.

![image](https://github.com/getcord/spr/assets/55964909/e37d5864-295c-48bf-a288-c02b8464082d)
