### PR TITLE
Fix updating PRs

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -136,7 +136,7 @@ impl GitHub {
 
     pub async fn get_github_user(login: String) -> Result<UserWithName> {
         octocrab::instance()
-            .get::<UserWithName, _, _>(format!("users/{}", login), None::<&()>)
+            .get::<UserWithName, _, _>(format!("/users/{}", login), None::<&()>)
             .await
             .map_err(Error::from)
     }
@@ -339,7 +339,7 @@ impl GitHub {
         octocrab::instance()
             .patch::<octocrab::models::pulls::PullRequest, _, _>(
                 format!(
-                    "repos/{}/{}/pulls/{}",
+                    "/repos/{}/{}/pulls/{}",
                     self.config.owner, self.config.repo, number
                 ),
                 Some(&updates),
@@ -359,7 +359,7 @@ impl GitHub {
         let _: Ignore = octocrab::instance()
             .post(
                 format!(
-                    "repos/{}/{}/pulls/{}/requested_reviewers",
+                    "/repos/{}/{}/pulls/{}/requested_reviewers",
                     self.config.owner, self.config.repo, number
                 ),
                 Some(&reviewers),


### PR DESCRIPTION
On certain cases SPR is calling methods which end-up going through [`Octocrab::parameterized_uri`](https://github.com/XAMPPRocky/octocrab/blob/main/src/lib.rs#L1416-L1438)

That method is calling `Uri::from_str` on the input, which fails when the URI string does not start with a forward slash.

This causes updates to fail.

```
fn test_failure_to_validate_uri() {
  use std::str::FromStr;
  assert!(http::Uri::from_str("repos/pulls/13345").is_err());
  assert!(http::Uri::from_str("/repos/pulls/13345").is_ok());
}
```