### PR TITLE
git2: allow pushing via ssh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1070,9 +1070,24 @@ checksum = "1c42fe03df2bd3c53a3a9c7317ad91d80c81cd1fb0caec8d7cc4cd2bfa10c222"
 dependencies = [
  "cc",
  "libc",
+ "libssh2-sys",
  "libz-sys",
  "openssl-sys",
  "pkg-config",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ dialoguer = "^0.12.0"
 env_logger = "0.11.8"
 futures = "^0.3.31"
 futures-lite = "^2.6.1"
-git2 = { version = "^0.20.2", default-features = false, features = ["https"]}
+git2 = { version = "^0.20.2", default-features = false, features = ["https", "ssh"]}
 git2-ext = "^0.6.3"
 graphql_client = "^0.14.0"
 http = "1.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,6 @@ serde = "^1.0.225"
 textwrap = "^0.16.2"
 tokio = { version = "^1.47.1", features = ["macros", "rt", "time"] }
 unicode-normalization = "^0.1.24"
+
+[lints.clippy]
+used-underscore-binding = "deny"

--- a/src/git_remote.rs
+++ b/src/git_remote.rs
@@ -33,9 +33,21 @@ impl GitRemote {
     {
         let mut remote = self.repo.remote_anonymous(&self.url)?;
         let mut cb = git2::RemoteCallbacks::new();
-        cb.credentials(move |_url, _username, _allowed_types| {
-            git2::Cred::userpass_plaintext("spr", &self.auth_token)
+        cb.credentials(move |url, username, allowed_types| {
+            debug!(
+                "remote callback: url={}, username={:?}, allowed={:?}",
+                url, username, allowed_types
+            );
+            if allowed_types.is_ssh_custom()
+                || allowed_types.is_ssh_key()
+                || allowed_types.is_ssh_interactive()
+            {
+                git2::Cred::ssh_key_from_agent(username.unwrap())
+            } else {
+                git2::Cred::userpass_plaintext("spr", &self.auth_token)
+            }
         });
+
         let mut connection =
             remote.connect_auth(dir, Some(cb), None).wrap_err_with(|| {
                 format!("Connection to git remote failed, url: {}", &self.url)


### PR DESCRIPTION
This ensures that pushing works even when users have configured their global gitconfig to always use SSH for pushing: using the entry `url.git@github.com:.pushinsteadof=https://github.com/`

See #241 